### PR TITLE
Add und update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Awesome extensions and projects built on LNBits.
 - [Tip Jars](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/tipjar) - Accept tips in Bitcoin, with small messages attached
 - [TPoS](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/tpos) - Mobile ready point-of-sale terminal
 - [userManager](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/usermanager) - Make and manage users/wallets (useful if using LNbits in your software stack)
-- [Watch Only wallet](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/watchonly) - Monitor an onchain wallet and generate addresses for onchain payments
-- [Withdraw](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/withdraw) - Mint LNURL-withdraws (Pull payments links, faucets, etc)
+- [Watch Only wallet](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/watchonly) - Monitor an onchain wallet and generate addresses for onchain payments
+- [Withdraw](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/withdraw) - Mint LNURL-withdraws (Pull payments links, faucets, etc)
 
 # Software Projects utilizing LNbits
 

--- a/README.md
+++ b/README.md
@@ -23,33 +23,34 @@ Awesome extensions and projects built on LNBits.
 
 # LNbits Extensions
 
-- [Bleskomat](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/bleskomat) - Connect one or more Bleskomat ATMs to LNbits wallet accounts
-- [BoltCard](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/boltcards) - Link a BoltCard (or other compatible NXP NTAG device) with a LNbits instance
-- [BoltzSwap](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/boltz) - Make swaps LN <-> onchain with Boltz Exchange
-- [Discord Bot](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/discordbot) - Provide LNbits wallets for all your Discord users
-- [Events](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/events) - Sell and register event tickets
-- [Invoices](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/invoices) - Create invoices that you can send to your client to pay online over Lightning
-- [Jukebox](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/jukebox) - Easily create a jukebox using Spotify/LNbits
-- [Livestream](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/livestream) - DJs receive tips live and split with a producer
-- [Lightning Address](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lnaddress) - Rent Lightning Addresses on your domain
-- [LNDhub](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lndhub) - Connect to your lnbits wallet from BlueWallet or Zeus
-- [LNtickets](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lnticket) - Pay-per-word tickets
-- [LNURLDevice](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lnurldevice) - For offline LNURL devices
-- [LNURLp](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lnurlp) - Mint LNURL-pay links (static LN payment QR codes, etc)
-- [LNURLPayOut](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/lnurlpayout) - Auto-dump a wallets funds to an LNURLpay
-- [Ngrok](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/ngrok) - Get a clearnet Ngrok url for your LNbits
-- [OfflineShop](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/watchonly) - Receive/verify lightning payments offline
-- [Paywall](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/paywall) - Lightning paywalls
-- [Satsdice](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/satsdice) - Create static LNURL powered satsdices
-- [SatsPay Server](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/satspay) - Create onchain and LN charges. Includes webhooks
-- [Scrub](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/scrub) - Automatically forward funds that get paid to a wallet/LNURL
-- [Split Payments](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/splitpayments) - Split Payments extension allows for distributing payments across multiple wallets.
-- [Streamer Copilot](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/copilot) - Tip for video streamers, triggers animations
-- [Stream Alerts](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/streamalerts) - Integrate Bitcoin Donations into your livestream alerts
-- [Subdomains](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/subdomains) - Rent a URLs subdomains
-- [Tip Jars](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/tipjar) - Accept tips in Bitcoin, with small messages attached
-- [TPoS](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/tpos) - Mobile ready point-of-sale terminal
-- [userManager](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/usermanager) - Make and manage users/wallets (useful if using LNbits in your software stack)
+- [Bleskomat](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/bleskomat) - Connect one or more Bleskomat ATMs to LNbits wallet accounts
+- [BoltCard](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/boltcards) - Link a BoltCard (or other compatible NXP NTAG device) with a LNbits instance
+- [BoltzSwap](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/boltz) - Make swaps LN <-> onchain with Boltz Exchange
+- [Cashu](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/cashu) - Create ecash mint for pegging in/out of ecash
+- [Discord Bot](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/discordbot) - Provide LNbits wallets for all your Discord users
+- [Events](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/events) - Sell and register event tickets
+- [Invoices](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/invoices) - Create invoices that you can send to your client to pay online over Lightning
+- [Jukebox](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/jukebox) - Easily create a jukebox using Spotify/LNbits
+- [Livestream](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/livestream) - DJs receive tips live and split with a producer
+- [Lightning Address](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lnaddress) - Rent Lightning Addresses on your domain
+- [LNDhub](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lndhub) - Connect to your lnbits wallet from BlueWallet or Zeus
+- [LNtickets](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lnticket) - Pay-per-word tickets
+- [LNURLDevice](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lnurldevice) - For offline LNURL devices
+- [LNURLp](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lnurlp) - Mint LNURL-pay links (static LN payment QR codes, etc)
+- [LNURLPayOut](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/lnurlpayout) - Auto-dump a wallets funds to an LNURLpay
+- [Ngrok](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/ngrok) - Get a clearnet Ngrok url for your LNbits
+- [OfflineShop](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/offlineshop) - Receive/verify lightning payments offline
+- [Paywall](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/paywall) - Lightning paywalls
+- [Satsdice](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/satsdice) - Create static LNURL powered satsdices
+- [SatsPay Server](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/satspay) - Create onchain and LN charges. Includes webhooks
+- [Scrub](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/scrub) - Automatically forward funds that get paid to a wallet/LNURL
+- [Split Payments](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/splitpayments) - Split Payments extension allows for distributing payments across multiple wallets.
+- [Streamer Copilot](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/copilot) - Tip for video streamers, triggers animations
+- [Stream Alerts](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/streamalerts) - Integrate Bitcoin Donations into your livestream alerts
+- [Subdomains](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/subdomains) - Rent a URLs subdomains
+- [Tip Jars](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/tipjar) - Accept tips in Bitcoin, with small messages attached
+- [TPoS](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/tpos) - Mobile ready point-of-sale terminal
+- [userManager](https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/usermanager) - Make and manage users/wallets (useful if using LNbits in your software stack)
 - [Watch Only wallet](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/watchonly) - Monitor an onchain wallet and generate addresses for onchain payments
 - [Withdraw](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/withdraw) - Mint LNURL-withdraws (Pull payments links, faucets, etc)
 
@@ -94,7 +95,11 @@ Awesome extensions and projects built on LNBits.
 
 # Hardware projects utilizing LNBits
 
-- [bitcoinPoS](https://github.com/arcbtc/bitcoinPoS) - Free and open-source bitcoin point-of-sale
+
+- [bitcoinSwitch](https://github.com/lnbits/bitcoinswitch) - Turn things on with bitcoin.
 - [bitcoinVend](https://github.com/arcbtc/bitcoinVend) - Offline Vending machine
-- [bitcoinSwitch](https://github.com/arcbtc/bitcoinSwitch) - Turn things on with bitcoin.
-- [LNURLPoS kit](https://nl.aliexpress.com/item/1005003589706292.html) - bitcoinPOS hardware kit from the official LILYGO store
+- [hardware wallet](https://github.com/lnbits/hardware-wallet) - DIY Bitcoin Hardware Wallet
+- [LNPoS](https://github.com/lnbits/lnpos) - Free and open-source bitcoin point-of-sale
+- [LNPoS kit](https://nl.aliexpress.com/item/1005003589706292.html) - bitcoinPOS hardware kit from the official LILYGO store
+- [fossa](https://github.com/lnbits/fossa) - Free and open source ATM
+


### PR DESCRIPTION
Add:
Cashu, hardware wallet & fossa

Updated:
https://github.com/lnbits/legend-lnbits/..   to   https://github.com/lnbits/lnbits/..
https://github.com/arcbtc/..   to   https://github.com/lnbits/..

Correction to:
[OfflineShop](https://github.com/lnbits/lnbits-legend/tree/main/lnbits/extensions/watchonly)